### PR TITLE
removed the line installing OSX headers

### DIFF
--- a/earnest_hatcher_init.sh
+++ b/earnest_hatcher_init.sh
@@ -5,8 +5,6 @@ GIT_DIRECTORY=${HOME}/git
 cd ~
 echo "Attempting to install xcode-select..."
 xcode-select --install
-echo "Attempting to install Mac OS SDK Headers (needed for pyenv later)"
-sudo installer -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg -target /
 mkdir ${GIT_DIRECTORY}
 cd ${GIT_DIRECTORY}
 git clone https://github.com/meetearnest/earnest-hatcher.git


### PR DESCRIPTION
removed the line installing OSX headers, because those break the pyenv install on 10.14.6 (Mojave), which our new laptops currently use as of this commit.